### PR TITLE
Support Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Nominatim",
+    products: [
+        .library(
+            name: "Nominatim",
+            targets: ["Nominatim"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "Nominatim",
+            path: "Pods/Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Added `Package.swift` to be able to use Swift Package Manager.
This makes it more convenient to install the NominatimKit from Xcode.